### PR TITLE
fix: use relative path in amplifier settings

### DIFF
--- a/.amplifier/settings.yaml
+++ b/.amplifier/settings.yaml
@@ -1,4 +1,4 @@
 bundle:
   active: specialists
   added:
-    specialists: file:///Users/chrispark/Projects/canvas-specialists
+    specialists: file://.


### PR DESCRIPTION
## Summary
- Replaces hardcoded `/Users/chrispark/Projects/canvas-specialists` with relative `file://.` so the bundle works on any machine

## Test plan
- [ ] Run `amplifier` from the repo root and verify the bundle loads without a "File not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)