### PR TITLE
fix: correct local module source paths in specialists behavior

### DIFF
--- a/behaviors/specialists.yaml
+++ b/behaviors/specialists.yaml
@@ -7,7 +7,7 @@ tools:
   - module: tool-web
     source: git+https://github.com/microsoft/amplifier-module-tool-web@main
   - module: tool-canvas-renderer
-    source: ./modules/tool-canvas-renderer
+    source: ../modules/tool-canvas-renderer
   - module: tool-skills
     config:
       skills:
@@ -24,7 +24,7 @@ agents:
 
 hooks:
   - module: hook-specialist-narration
-    source: ./modules/hook-specialist-narration
+    source: ../modules/hook-specialist-narration
 
 spawn:
   exclude_tools: [write_file, edit_file, apply_patch]


### PR DESCRIPTION
## Summary

- Fixes incorrect relative source paths in `behaviors/specialists.yaml` that prevented the specialist behavior loader from resolving local modules correctly.
- The paths used directory-relative references instead of repo-root-relative references, causing module loading failures at cold-start time.

## What changed

| File | Change |
|------|--------|
| `behaviors/specialists.yaml` | Corrected 2 source path entries to use proper relative paths |

## Test plan

```bash
# Verify specialists.yaml parses correctly
python -c "import yaml; yaml.safe_load(open('behaviors/specialists.yaml'))"

# Run full test suite (302 tests pass)
pytest tests/ -v
```

All 302 existing tests pass on this branch.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)